### PR TITLE
Fix ambiguous Lua escapes in lua_string()

### DIFF
--- a/pipeline/generate.py
+++ b/pipeline/generate.py
@@ -9,7 +9,10 @@ from .model import Alignment
 def lua_string(value: str) -> str:
     value = value.replace("\\", "\\\\").replace('"', '\\"')
     value = value.replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
-    value = value.replace("\v", "\\11").replace("\f", "\\12")
+    # Pad to three digits: Lua reads \ddd greedily, so "\12" followed by a
+    # digit parses as a single character. French ordinals put a digit right
+    # after a page break, turning "\12" + "1er" into chr(121) + "er".
+    value = value.replace("\v", "\\011").replace("\f", "\\012")
     return '"' + value + '"'
 
 


### PR DESCRIPTION
# Fix ambiguous Lua escapes in `lua_string()`

## Problem

`pipeline/generate.py` emits two-digit decimal escapes for the page-break
control bytes:

```python
value = value.replace("\v", "\\11").replace("\f", "\\12")
```

Lua reads `\ddd` **greedily, up to three digits**. When the character
following a page break is itself a digit, the escape swallows it:

```lua
"\12" .. "1er"   -->  parses as  "\121" .. "er"  -->  "yer"
```

`\121` is `chr(121)`, the letter `y`. The page break disappears and the first
digit of the following word is eaten.

This is not hypothetical for languages that use digits mid-sentence. French
ordinals (`1er`, `2e`) and dated diary entries hit it directly.

## Evidence in the released 0.4.2 archive

Measured on the published `translation-fr-0.4.2.zip`, not on a local rebuild:

```
official/lang/dialogue.lua   ambiguous escapes: 16
official/lang/strings.lua    ambiguous escapes: 0
```

Sixteen occurrences ship in the released French mod today. Example context
from `dialogue.lua`, a Pokémon Mansion diary entry:

```
...Rapport:\121er ...
```

The intended output is a page break followed by `1er`; what Lua parses is
`y` followed by `er`.

To reproduce against any built catalogue:

```python
import re, sys
from pathlib import Path

# a shell grep pattern starting with \1 is read as a back-reference and
# silently matches nothing, so this has to be counted in Python
AMBIG = re.compile(r"\\1[12](?=\d)")
for arg in sys.argv[1:]:
    body = Path(arg).read_text(encoding="utf-8")
    print(f"{arg}: {len(AMBIG.findall(body))}")
```

## Fix

Pad to three digits, which is unambiguous regardless of what follows:

```python
value = value.replace("\v", "\\011").replace("\f", "\\012")
```

One line, no behaviour change for any string that was already correct: `\011`
and `\12` denote the same character, and `\011` cannot absorb a following
digit.

After the change, the same measurement returns `0` for both catalogues, and
the affected dialogue lines render their page break correctly in game.

## Languages affected

Any target language whose text places a digit immediately after a page break.
Confirmed in `fr`; `de`, `es` and `it` share the same diary and ordinal
constructions and are worth re-measuring after the fix.
