### PR TITLE
Repair worksheet mojibake so accented ROM keys match the corpus

### DIFF
--- a/pipeline/join.py
+++ b/pipeline/join.py
@@ -96,6 +96,23 @@ def _unquote(value: str) -> str:
     return re.sub(r"\\([0-7]{1,3})", lambda m: chr(int(m.group(1), 8)), value)
 
 
+def _repair_mojibake(value: str) -> str:
+    """Undo one UTF-8-read-as-cp1252 round trip.
+
+    Modkit emits worksheets whose non-ASCII bytes have already been decoded
+    once as cp1252, so "é" arrives as "Ã©". Keys mangled this way never match
+    the corpus, which silently drops the eleven ROM names carrying accents or
+    gender signs. The repair is self-checking: a string that is not mojibake
+    either lacks the marker or fails the round trip, and is returned untouched.
+    """
+    if not any(c in value for c in "ÃÂ"):
+        return value
+    try:
+        return value.encode("cp1252").decode("utf-8")
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return value
+
+
 def read_worksheets(root: str | Path) -> dict[str, list[WorksheetEntry]]:
     root = Path(root); result = {}
     for catalog in CATALOGS:
@@ -106,7 +123,9 @@ def read_worksheets(root: str | Path) -> dict[str, list[WorksheetEntry]]:
                 if not line or line.startswith("#") or "\t" not in line:
                     continue
                 key, english = line.split("\t", 1)
-                entries.append(WorksheetEntry(_unquote(key), _unquote(english), catalog))
+                entries.append(WorksheetEntry(_repair_mojibake(_unquote(key)),
+                                              _repair_mojibake(_unquote(english)),
+                                              catalog))
         result[catalog] = entries
     return result
 


### PR DESCRIPTION
# Repair worksheet mojibake so accented ROM keys match the corpus

## Problem

`read_worksheets()` in `pipeline/join.py` reads Modkit worksheets as UTF-8.
The bytes arriving in those worksheets have already been decoded once as
cp1252, so every non-ASCII character is doubly encoded:

```
POKéDEX   ->  POKÃ©DEX
NIDORAN♀  ->  NIDORANâ™€
```

The join matches worksheet keys against corpus keys. A mangled key matches
nothing, so the row is dropped — silently, because a dropped row is
indistinguishable from a row the corpus does not cover.

Every ROM name carrying an accent or a gender sign is affected.

## Evidence in the released 0.4.2 archive

Measured on the published `translation-fr-0.4.2.zip`:

```
  NIDORAN_F            EMPTY
  NIDORAN_M            EMPTY
  POKEDEX              EMPTY
  POKE_BALL            EMPTY
  POKE_DOLL            EMPTY
  POKE_FLUTE           EMPTY
  OPP_COOLTRAINER_F    EMPTY
  OPP_COOLTRAINER_M    EMPTY
  OPP_JR_TRAINER_F     EMPTY
  OPP_JR_TRAINER_M     EMPTY
  OPP_POKEMANIAC       EMPTY

  empty in official: 11/11
```

All eleven ship untranslated in the released French mod. In game that means
the Poké Ball, the Pokédex, the Poké Doll, the Poké Flute, both Nidoran forms
and four trainer classes stay English while everything around them is French.

Catalogue totals move from `3096/3107` to `3107/3107` once the keys match.

## Fix

Undo exactly one cp1252/UTF-8 round trip when reading a worksheet:

```python
def _repair_mojibake(value: str) -> str:
    if not any(c in value for c in "ÃÂ"):
        return value
    try:
        return value.encode("cp1252").decode("utf-8")
    except (UnicodeEncodeError, UnicodeDecodeError):
        return value
```

applied to both the key and the English text in `read_worksheets()`.

The repair is self-checking in two ways, so a correctly encoded worksheet is
never damaged:

1. text without the `Ã`/`Â` marker is returned untouched — those are the only
   lead bytes a cp1252-misread UTF-8 accent can produce;
2. text that carries the marker but is not in fact double-encoded fails the
   round trip and is returned untouched.

Measured on the French worksheets: **615 rows repaired, 0 rows damaged**.

## Note on scope

This fixes the symptom at the point of use. The cleaner fix may belong in
Modkit's worksheet writer, so the encoding is correct at the source. If you
prefer that direction, the measurements above should transfer unchanged — but
this patch also keeps existing worksheets working without regenerating them.
