### PR TITLE
Force UTF-8 subprocess text decoding in the internal worker directly

### DIFF
--- a/build_translation.py
+++ b/build_translation.py
@@ -2,11 +2,33 @@
 """Run the interactive Gen1Recomp translation mod builder."""
 
 import runpy
+import subprocess
 import sys
 import importlib.util
 from pathlib import Path
 
 from pipeline.builder import main
+
+
+def _force_utf8_subprocess_text_decoding() -> None:
+    """The frozen bootstrap re-spawns this executable as the internal
+    worker, and PyInstaller's own interpreter startup doesn't reliably
+    propagate PYTHONUTF8 to that new process. Vendored tools invoked here
+    (gen1recomp's tools/modkit.py dump_dataset()) call
+    subprocess.run(text=True) with no explicit encoding, which then falls
+    back to the OS locale codepage (e.g. cp1252 on Windows) and crashes on
+    dumped text outside it. Patch Popen directly so text-mode subprocess
+    calls decode as UTF-8 regardless of locale, matching the encoding the
+    Lua sources are written in.
+    """
+    original_init = subprocess.Popen.__init__
+
+    def _init(self, *args, **kwargs):
+        if kwargs.get("encoding") is None and (kwargs.get("text") or kwargs.get("universal_newlines")):
+            kwargs["encoding"] = "utf-8"
+        original_init(self, *args, **kwargs)
+
+    subprocess.Popen.__init__ = _init
 
 
 def _internal_worker() -> int:
@@ -18,6 +40,7 @@ def _internal_worker() -> int:
         if entry not in sys.path:
             sys.path.insert(0, entry)
     sys.argv[:] = [str(script_path), *arguments]
+    _force_utf8_subprocess_text_decoding()
     runpy.run_path(str(script_path), run_name="__main__")
     return 0
 

--- a/build_translation_gui.py
+++ b/build_translation_gui.py
@@ -2,10 +2,32 @@
 """Run the Tkinter Gen1Recomp translation mod builder."""
 
 import runpy
+import subprocess
 import sys
 from pathlib import Path
 
 from pipeline.gui import main
+
+
+def _force_utf8_subprocess_text_decoding() -> None:
+    """The frozen bootstrap re-spawns this executable as the internal
+    worker, and PyInstaller's own interpreter startup doesn't reliably
+    propagate PYTHONUTF8 to that new process. Vendored tools invoked here
+    (gen1recomp's tools/modkit.py dump_dataset()) call
+    subprocess.run(text=True) with no explicit encoding, which then falls
+    back to the OS locale codepage (e.g. cp1252 on Windows) and crashes on
+    dumped text outside it. Patch Popen directly so text-mode subprocess
+    calls decode as UTF-8 regardless of locale, matching the encoding the
+    Lua sources are written in.
+    """
+    original_init = subprocess.Popen.__init__
+
+    def _init(self, *args, **kwargs):
+        if kwargs.get("encoding") is None and (kwargs.get("text") or kwargs.get("universal_newlines")):
+            kwargs["encoding"] = "utf-8"
+        original_init(self, *args, **kwargs)
+
+    subprocess.Popen.__init__ = _init
 
 
 def _internal_worker() -> int:
@@ -17,6 +39,7 @@ def _internal_worker() -> int:
         if entry not in sys.path:
             sys.path.insert(0, entry)
     sys.argv[:] = [str(script_path), *arguments]
+    _force_utf8_subprocess_text_decoding()
     runpy.run_path(str(script_path), run_name="__main__")
     return 0
 

--- a/tests/test_internal_worker.py
+++ b/tests/test_internal_worker.py
@@ -1,0 +1,61 @@
+import subprocess
+import unittest
+
+import build_translation
+import build_translation_gui
+
+
+class ForceUtf8SubprocessTextDecodingTests(unittest.TestCase):
+    """gen1recomp's own tools/modkit.py calls subprocess.run(text=True) with
+    no explicit encoding, which falls back to the OS locale codepage and
+    crashes on non-Latin-1 dumped text on Windows. Both entry points patch
+    Popen before running vendored tools through --internal-worker; lock in
+    that patch here since neither script is otherwise covered by tests.
+    """
+
+    def _run_patched(self, force_utf8, **kwargs):
+        original_init = subprocess.Popen.__init__
+        try:
+            force_utf8()
+            return subprocess.Popen(
+                ["python3", "-c", "import sys; sys.stdout.buffer.write(bytes.fromhex('e697a5e69cace8aa9e'))"],
+                stdout=subprocess.PIPE, **kwargs,
+            )
+        finally:
+            subprocess.Popen.__init__ = original_init
+
+    def test_cli_worker_forces_utf8_when_text_mode_and_no_encoding(self):
+        process = self._run_patched(build_translation._force_utf8_subprocess_text_decoding, text=True)
+        try:
+            self.assertEqual(process.communicate()[0], "日本語")
+        finally:
+            process.wait()
+
+    def test_gui_worker_forces_utf8_when_universal_newlines_and_no_encoding(self):
+        process = self._run_patched(build_translation_gui._force_utf8_subprocess_text_decoding, universal_newlines=True)
+        try:
+            self.assertEqual(process.communicate()[0], "日本語")
+        finally:
+            process.wait()
+
+    def test_explicit_encoding_is_not_overridden(self):
+        process = self._run_patched(
+            build_translation_gui._force_utf8_subprocess_text_decoding, text=True, encoding="latin-1",
+        )
+        try:
+            decoded = process.communicate()[0]
+        finally:
+            process.wait()
+        self.assertNotEqual(decoded, "日本語")
+
+    def test_binary_mode_is_left_untouched(self):
+        process = self._run_patched(build_translation_gui._force_utf8_subprocess_text_decoding)
+        try:
+            raw = process.communicate()[0]
+        finally:
+            process.wait()
+        self.assertEqual(raw, bytes.fromhex("e697a5e69cace8aa9e"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
env["PYTHONUTF8"] = "1" (previous commit on this line of work) should make CPython's subprocess._text_encoding() return "utf-8" instead of falling back to the OS locale codepage, per stdlib source. But a real Windows GUI build still reproduced the identical cp1252 decode crash in gen1recomp's tools/modkit.py dump_dataset() afterwards, on a build whose tag already included that env var change -- so PyInstaller's frozen bootstrap re-spawning this executable as --internal-worker apparently doesn't propagate/honor PYTHONUTF8 the same way a normal python.exe invocation would.

Rather than continue trusting environment-variable propagation through an opaque frozen re-exec, patch subprocess.Popen directly inside _internal_worker(), in both build_translation.py and build_translation_gui.py, before handing control to the vendored script via runpy. Any text-mode Popen call without an explicit encoding then decodes as UTF-8 regardless of locale or how the interpreter was started -- verified against a real cp1252-vs-UTF-8 decode locally, and covered by tests/test_internal_worker.py.

The env["PYTHONUTF8"] = "1"  change stays in place: it's still correct for the unfrozen dev/CLI path, which spawns a real python.exe that does read its own startup environment normally.