### PR TITLE
Fix the frozen build silently dropping most of config/gsc/

### DIFF
--- a/packaging/translation_builder.spec
+++ b/packaging/translation_builder.spec
@@ -15,18 +15,19 @@ entrypoint = ROOT / ("build_translation_gui.py" if variant == "gui" else "build_
 runtime = ROOT / "packaging" / "runtime" / "luajit"
 datas = []
 binaries = []
-for relative in (
-    "config/pipeline.toml", "config/shared/engine_manifest.json", "config/rby/engine_scope.json",
-    "config/rby/terminology_anchors.json", "config/rby/semantic_anchors.json", "config/rby/semantic_anchor_decisions.json",
-    "config/rby/literal_handlers.json", "config/rby/yellow_coverage_exceptions.json",
-    "config/gsc/semantic_anchors.json", "config/gsc/pointer_decisions.json",
-    "config/gsc/literal_handlers.json", "config/gsc/placeholder_decisions.json",
-    "config/gsc/silver_pointer_aliases.json",
-    "config/rom_paths.example.toml",
-    "pyproject.toml",
-):
+for relative in ("pyproject.toml",):
     source = ROOT / relative
     datas.append((str(source), str(Path(relative).parent)))
+# Naming every config/{rby,gsc,shared} file individually has already fallen
+# out of sync with real releases more than once as new engine/Crystal config
+# files landed. Bundle the whole config/ tree instead -- except
+# config/rom_paths.toml, the gitignored file holding the packager's own
+# private local ROM paths -- so a future addition here does not silently
+# repeat the same gap, the same reasoning already applied to overrides/ and
+# tools/ below.
+for source in (ROOT / "config").rglob("*"):
+    if source.is_file() and source.name != "rom_paths.toml":
+        datas.append((str(source), str(source.parent.relative_to(ROOT))))
 for source in (ROOT / "overrides").rglob("*"):
     if source.is_file() and source.name != "rom_paths.toml":
         datas.append((str(source), str(source.parent.relative_to(ROOT))))


### PR DESCRIPTION
The PyInstaller spec named every config/{rby,gsc,shared} file to bundle individually. That list fell out of sync with real releases as new engine/Crystal config files landed over time: 9 of the 14 files actually under config/gsc/ were missing from it, including crystal_string_selectors.json -- a real frozen Gold/Silver/Crystal build now fails immediately with "No such file or directory: ...config\gsc\crystal_string_selectors.json" (reported against the v0.8.2 Windows GUI release).

Bundle the whole config/ tree instead, except config/rom_paths.toml (gitignored, holds the packager's own private local ROM paths) -- the same reasoning already applied to overrides/ and tools/ in this same spec file, so a future config file addition cannot silently repeat this gap again. pyproject.toml stays on its own explicit line since it lives outside config/.

Verified with a real PyInstaller 6.14.2 build (CLI variant, Linux): --self-check passes and every config/gsc/*.json file, including crystal_string_selectors.json, is now present in the built archive (confirmed via PyInstaller's own archive_viewer, not just a directory listing). Adds ~384KB across the 9 previously-missing files, out of a 552KB config/ tree total -- negligible next to the rest of a one-file build (Python + Pillow + LuaJIT already bundled).